### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: test
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/Wbaker7702/Bug-free-journey/security/code-scanning/1](https://github.com/Wbaker7702/Bug-free-journey/security/code-scanning/1)

To fix the problem, explicitly set the `permissions` block in the workflow to restrict the `GITHUB_TOKEN` to the least privilege required. Since the workflow only checks out code and runs tests (does not appear to require any write access), the minimal permission of `contents: read` is sufficient. This can be set at the workflow level (applies to all jobs) or at the job level (applies only to the `check` job). The best practice is to set it at the workflow level unless a job requires different permissions. To implement the fix, add the following block after the `name:` and before the `on:` block in `.github/workflows/test.yml`:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow permissions to enforce read-only access to repository contents during test runs, aligning with least-privilege principles and improving security posture.  
  * No changes to triggers, environment, or job steps; existing test behavior remains unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->