### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/appknox.yml
+++ b/.github/workflows/appknox.yml
@@ -20,6 +20,9 @@
 #    action executes, check the 'Security' tab for results
 
 name: Appknox
+permissions:
+  contents: read
+  security-events: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Wbaker7702/Bug-free-journey/security/code-scanning/2](https://github.com/Wbaker7702/Bug-free-journey/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow to restrict the GITHUB_TOKEN permissions to only those required. The workflow needs to upload SARIF files to GitHub Advanced Security, which requires `security-events: write`. It is also best practice to set `contents: read` to allow code checkout, but not write access. The `permissions` block should be added at the workflow level (above `jobs:`) to apply to all jobs, unless a job needs different permissions. Edit `.github/workflows/appknox.yml` to insert the following block after the `name:` line and before `on:`:

```yaml
permissions:
  contents: read
  security-events: write
```

No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow permissions configuration. No changes to workflow triggers, steps, or execution behavior.
  * Internal automation settings adjusted to align with current operational requirements.
  * No user-facing impact; application functionality remains unchanged.

* **Documentation**
  * Not applicable.

* **Refactor**
  * Not applicable.

* **Bug Fixes**
  * Not applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->