### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -17,6 +17,9 @@
 # Read the official documentation here : https://learn.microsoft.com/en-us/azure/defender-for-cloud/quickstart-onboard-github
 
 name: "Microsoft Defender For Devops"
+permissions:
+  contents: read
+  security-events: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Wbaker7702/Bug-free-journey/security/code-scanning/3](https://github.com/Wbaker7702/Bug-free-journey/security/code-scanning/3)

To fix the issue, we should explicitly set the `permissions` key to restrict the workflow's permissions to the minimum required. The minimal starting point is `contents: read`, which allows the job to check out code but not make changes to it. Since the workflow uploads SARIF files (for the GitHub "Security" tab), it likely also needs `security-events: write` permission for that step. However, unless the workflow needs to write to other scopes (e.g., issues, pull-requests), we should avoid adding them.  
The best practice is to set the `permissions` key at the top level of the workflow (just after the `name:` and before `on:`), which applies to all jobs unless otherwise overridden.  
**Changes to make:**
- Insert a `permissions:` block after line 19 (after the `name:`), with at least `contents: read` and `security-events: write`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
